### PR TITLE
Clear plant input

### DIFF
--- a/src/AddPlant.tsx
+++ b/src/AddPlant.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import ColorBlocks from "./ColorBlocks";
 import DateSelect from "./DateSelect";
-import { BloomTime, DateSelectionObj } from "./GardenPlannerInterfaces";
+import { BloomFruitTimeObj, DateSelectionObj } from "./GardenPlannerInterfaces";
 // Will need to re-factor these into their own file to be
 // able to import and use the interfaces in the
 // main GardenPlanner app and also here.
@@ -33,9 +33,9 @@ import { BloomTime, DateSelectionObj } from "./GardenPlannerInterfaces";
 interface AddPlantsProps {
   plantName: string;
   onNameChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
-  bloomTime: BloomTime;
-  fruitTime: BloomTime;
-  otherTime: BloomTime;
+  bloomTime: BloomFruitTimeObj;
+  fruitTime: BloomFruitTimeObj;
+  otherTime: BloomFruitTimeObj;
   onBloomTimeChange: (selectedMonthObj: DateSelectionObj) => void;
   onFruitTimeChange: (selectedMonthObj: DateSelectionObj) => void;
   onOtherTimeChange: (selectedMonthObj: DateSelectionObj) => void;
@@ -95,6 +95,7 @@ export default function AddPlant(props: AddPlantsProps) {
             <DateSelect
               onDateSelectChange={props.onBloomTimeChange}
               eventTypeForDate="bloom"
+              // dateStateForEventType={props.bloomTime}
             />
             {/* Will need to make a better month selector myself because
          Firefox and Safari both don't support ticks and tick numbers for sliders
@@ -154,6 +155,7 @@ export default function AddPlant(props: AddPlantsProps) {
             <DateSelect
               onDateSelectChange={props.onFruitTimeChange}
               eventTypeForDate="fruit"
+              // dateStateForEventType={props.fruitTime}
             />
             <div id="fruit-attracted-wildlife-div">
               <p id="fruit-attracted-wildlife">Attracts</p>
@@ -188,6 +190,7 @@ export default function AddPlant(props: AddPlantsProps) {
             <DateSelect
               onDateSelectChange={props.onOtherTimeChange}
               eventTypeForDate="other"
+              // dateStateForEventType={props.otherTime}
             />
             <div id="other-attracted-wildlife-div">
               <p id="other-attracted-wildlife">Attracts</p>

--- a/src/AddPlant.tsx
+++ b/src/AddPlant.tsx
@@ -99,6 +99,7 @@ export default function AddPlant(props: AddPlantsProps) {
             <DateSelect
               onDateSelectChange={props.onBloomTimeChange}
               eventTypeForDate="bloom"
+              eventTypeValue={props.bloomTime}
               // dateStateForEventType={props.bloomTime}
             />
             {/* Will need to make a better month selector myself because
@@ -159,6 +160,7 @@ export default function AddPlant(props: AddPlantsProps) {
             <DateSelect
               onDateSelectChange={props.onFruitTimeChange}
               eventTypeForDate="fruit"
+              eventTypeValue={props.fruitTime}
               // dateStateForEventType={props.fruitTime}
             />
             <div id="fruit-attracted-wildlife-div">
@@ -194,6 +196,7 @@ export default function AddPlant(props: AddPlantsProps) {
             <DateSelect
               onDateSelectChange={props.onOtherTimeChange}
               eventTypeForDate="other"
+              eventTypeValue={props.otherTime}
               // dateStateForEventType={props.otherTime}
             />
             <div id="other-attracted-wildlife-div">

--- a/src/AddPlant.tsx
+++ b/src/AddPlant.tsx
@@ -33,6 +33,7 @@ import { BloomFruitTimeObj, DateSelectionObj } from "./GardenPlannerInterfaces";
 interface AddPlantsProps {
   plantName: string;
   onNameChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  bloomColorName: string;
   bloomTime: BloomFruitTimeObj;
   fruitTime: BloomFruitTimeObj;
   otherTime: BloomFruitTimeObj;
@@ -76,7 +77,10 @@ export default function AddPlant(props: AddPlantsProps) {
         </div>
         <label htmlFor="color-block-holder">Bloom color</label>
         <div id="color-block-holder">
-          <ColorBlocks onBloomColorChange={props.onBloomColorChange} />
+          <ColorBlocks
+            onBloomColorChange={props.onBloomColorChange}
+            bloomColorName={props.bloomColorName}
+          />
           {/* <input
             id="bloom-color"
             type="color"

--- a/src/ColorBlocks.tsx
+++ b/src/ColorBlocks.tsx
@@ -1,27 +1,49 @@
-import { useState, useEffect } from "react";
+import { useEffect } from "react";
 
 interface ColorBlocksProps {
   onBloomColorChange: (hexColor: string, colorName: string) => void;
+  bloomColorName: string;
 }
 
 export default function ColorBlocks(props: ColorBlocksProps) {
-  const [currColor, setCurrentColor] = useState("");
+  //const [currColor, setCurrentColor] = useState(props.bloomColor);
 
   // Update the selected border every time the color selection is changed
+  // as kept track of the state from the GardenPlanner component.
+  // the handleColorChange function on click removes any color selection,
+  // then calls the onBloomColorChange function provided in props
+  // to update the state in the GardenPlanner component, and that
+  // then triggers this useEffect. This keeps the bloom color toggling
+  // as before, but also allows the GardenPlanner component to directly
+  // set the selected color (used to reset the color on submission
+  // and to enable editing of an existing plant)
   useEffect(() => {
+    // console.log("tests");
+    // console.log(props.bloomColorName);
     const allColorButtons = document.querySelectorAll(".color-block-button");
     allColorButtons.forEach((colorButton) => {
-      if (colorButton.innerHTML === currColor) {
-        colorButton.classList.toggle("selected-color");
-      } else {
-        // Calling remove on the classList is safe even if the 'selected-color'
-        // class isn't in the classList.
-        colorButton.classList.remove("selected-color");
+      if (colorButton.innerHTML === props.bloomColorName) {
+        // All selected color class labels are removed on click
+        // in the handleColorChange function below, so this needs
+        // to add it to the currently selected bloom color.
+        // (Removes problem with using toggle requiring a double click to get selected)
+        colorButton.classList.add("selected-color");
       }
     });
-  }, [currColor]);
+  }, [props.bloomColorName]);
 
-  const { onBloomColorChange } = props;
+  const { onBloomColorChange, bloomColorName } = props;
+
+  // const allColorButtons = document.querySelectorAll(".color-block-button");
+  // allColorButtons.forEach((colorButton) => {
+  //   if (colorButton.innerHTML === bloomColor) {
+  //     colorButton.classList.toggle("selected-color");
+  //   } else {
+  //     // Calling remove on the classList is safe even if the 'selected-color'
+  //     // class isn't in the classList.
+  //     colorButton.classList.remove("selected-color");
+  //   }
+  // });
 
   const colors = {
     Red: "#ff0033",
@@ -48,7 +70,16 @@ export default function ColorBlocks(props: ColorBlocksProps) {
       event.currentTarget.style.backgroundColor,
       event.currentTarget.innerHTML
     );
-    setCurrentColor(event.currentTarget.innerHTML);
+    const allColorButtons = document.querySelectorAll(".color-block-button");
+    allColorButtons.forEach((colorButton) => {
+      // Calling remove on the classList is safe even if the 'selected-color'
+      // class isn't in the classList.
+      colorButton.classList.remove("selected-color");
+    });
+
+    //event.currentTarget.classList.toggle("selected-color");
+
+    //setCurrentColor(event.currentTarget.innerHTML);
   }
 
   return (
@@ -66,6 +97,9 @@ export default function ColorBlocks(props: ColorBlocksProps) {
           classList += " light-text";
         } else {
           classList += " dark-text";
+        }
+        if (colorName === bloomColorName) {
+          classList += " selected-color";
         }
 
         return (

--- a/src/DateSelect.tsx
+++ b/src/DateSelect.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { DateSelectionObj } from "./GardenPlannerInterfaces";
+import { DateSelectionObj, BloomFruitTimeObj } from "./GardenPlannerInterfaces";
 // This accommodates the keys being 1-12 (or any number) without any hardcoding.
 // Could make more specific to only allow 1-12 and that would also be OK.
 // interface DateSelectionObj {
@@ -9,15 +9,16 @@ import { DateSelectionObj } from "./GardenPlannerInterfaces";
 interface DateSelectProps {
   onDateSelectChange: (selectedMonthObj: DateSelectionObj) => void;
   eventTypeForDate: string;
+  eventTypeValue: BloomFruitTimeObj;
   //   dateStateForEventType: BloomTime;
 }
 
 export default function DateSelect(props: DateSelectProps) {
-  const [selectedMonths, setSelectedMonths] = useState({});
+  //const [selectedMonths, setSelectedMonths] = useState({});
   const [disableAllSelection, setDisableAllSelection] = useState(false);
   // Disable by default because when page loaded, no buttons are selected.
   const [disableNoneSelection, setDisableNoneSelection] = useState(true);
-  const { onDateSelectChange, eventTypeForDate } = props;
+  const { onDateSelectChange, eventTypeForDate, eventTypeValue } = props;
 
   // The bloom/fruiting/other time state objects in the main garden planner
   // are objects with keys 'monthNumAsStringArray' and 'monthNameArray'
@@ -40,11 +41,14 @@ export default function DateSelect(props: DateSelectProps) {
 
   //setSelectedMonths(selectedMonthObject);
 
+  // useEffect(() => {
+  //   console.log("The new selected months are:");
+  //   console.log(selectedMonths);
+  // }, [selectedMonths]);
   useEffect(() => {
-    console.log("The new selected months are:");
-    console.log(selectedMonths);
-  }, [selectedMonths]);
-
+    console.log("In use effect");
+    console.log(eventTypeValue);
+  }, [eventTypeValue]);
   useEffect(() => {
     console.log("in disable effect");
     const allMonthsButton = document.querySelector(
@@ -118,7 +122,7 @@ export default function DateSelect(props: DateSelectProps) {
     // Use the months object directly to set the state because
     // all months have been selected.
     onDateSelectChange(months);
-    setSelectedMonths(months);
+    //setSelectedMonths(months);
     setDisableAllSelection(true);
     setDisableNoneSelection(false);
   }
@@ -134,7 +138,7 @@ export default function DateSelect(props: DateSelectProps) {
     // Use empty object to set the state because none of the months
     // are selected
     onDateSelectChange({});
-    setSelectedMonths({});
+    //setSelectedMonths({});
     setDisableNoneSelection(true);
     setDisableAllSelection(false);
   }
@@ -164,14 +168,14 @@ export default function DateSelect(props: DateSelectProps) {
       // and is not already in the list
       if (
         monthButton.classList.contains("selected-month") &&
-        !Object.keys(selectedMonths).includes(monthNum.toString())
+        !Object.keys(eventTypeValue).includes(monthNum.toString())
       ) {
         //Need to re-establish the key/value types
         const newSelectedMonths: { [key: number]: string } = {
-          ...selectedMonths,
+          ...eventTypeValue,
         };
         newSelectedMonths[monthNum] = monthName;
-        setSelectedMonths(newSelectedMonths);
+        //setSelectedMonths(newSelectedMonths);
         onDateSelectChange(newSelectedMonths);
         // Activate the all/none selectors depending on
         // how many months are selected
@@ -189,15 +193,15 @@ export default function DateSelect(props: DateSelectProps) {
       }
       // REMOVE any months from the list that aren't selected any longer.
       if (
-        Object.keys(selectedMonths).includes(monthNum.toString()) &&
+        Object.keys(eventTypeValue).includes(monthNum.toString()) &&
         !monthButton.classList.contains("selected-month")
       ) {
         // deconstruct the selectedMonths obj using the dynamic value of monthNum
         // to extract the part to remove (need to do : assignment for dynamic destructuring to work)
         // Need to re-establish the key:value types
         const { [monthNum]: toRemove, ...rest }: { [key: number]: string } =
-          selectedMonths;
-        setSelectedMonths({ ...rest });
+          eventTypeValue;
+        //setSelectedMonths({ ...rest });
         onDateSelectChange({ ...rest });
 
         if (Object.keys(rest).length >= 1) {

--- a/src/DateSelect.tsx
+++ b/src/DateSelect.tsx
@@ -9,6 +9,7 @@ import { DateSelectionObj } from "./GardenPlannerInterfaces";
 interface DateSelectProps {
   onDateSelectChange: (selectedMonthObj: DateSelectionObj) => void;
   eventTypeForDate: string;
+  //   dateStateForEventType: BloomTime;
 }
 
 export default function DateSelect(props: DateSelectProps) {
@@ -17,6 +18,28 @@ export default function DateSelect(props: DateSelectProps) {
   // Disable by default because when page loaded, no buttons are selected.
   const [disableNoneSelection, setDisableNoneSelection] = useState(true);
   const { onDateSelectChange, eventTypeForDate } = props;
+
+  // The bloom/fruiting/other time state objects in the main garden planner
+  // are objects with keys 'monthNumAsStringArray' and 'monthNameArray'
+  // where the values are arrays of strings either of the month numbers
+  // or the 3-letter month abbreviations. These are derived from the selectedMonths
+  // state object used here in this component, which has format {1:"Jan",2:"Feb",...}
+  // when the state is getting send down from the main component to here
+  // (in case of clearing form after submit or editing a plant's characteristics)
+  // then need to back-transform the two arrays sent to this component to the single object
+  // that it uses. Not ideal, but a workaround for a single shared state (did not anticipate needing
+  // to have the dates set from the main component when I built these date selectors)
+
+  // let selectedMonthObject: { [key: number]: string } = {};
+  // if (dateStateForEventType.monthNumAsStringArray.length > 0) {
+  //   dateStateForEventType.monthNumAsStringArray.forEach((numString, index) => {
+  //     selectedMonthObject[Number.parseInt(numString, 10)] =
+  //       dateStateForEventType.monthNameArray[index];
+  //   });
+  // }
+
+  //setSelectedMonths(selectedMonthObject);
+
   useEffect(() => {
     console.log("The new selected months are:");
     console.log(selectedMonths);

--- a/src/DateSelect.tsx
+++ b/src/DateSelect.tsx
@@ -41,14 +41,40 @@ export default function DateSelect(props: DateSelectProps) {
 
   //setSelectedMonths(selectedMonthObject);
 
-  // useEffect(() => {
-  //   console.log("The new selected months are:");
-  //   console.log(selectedMonths);
-  // }, [selectedMonths]);
+  // This updates the date selector to mirror the date selected state
+  // that's currently being held by the main GardenPlanner component.
+  // This is currently used to clear the date selections after plant form
+  // submission and will be used to allow editing the information of an existing
+  // plant by pre-populating the dates for that plant.
+  // It takes care of resetting the all or none selection buttons
+  // too, as needed.
   useEffect(() => {
-    console.log("In use effect");
-    console.log(eventTypeValue);
-  }, [eventTypeValue]);
+    // console.log("In use effect");
+    // console.log(eventTypeValue);
+
+    const monthButtonList = document.querySelectorAll(
+      `.${eventTypeForDate}-month`
+    ) as NodeListOf<HTMLButtonElement>;
+    monthButtonList.forEach((monthButton) => {
+      if (Object.values(eventTypeValue).includes(monthButton.innerText)) {
+        console.log("button match");
+        monthButton.classList.add("selected-month");
+      } else {
+        // this class removal is safe even if the class doesn't
+        monthButton.classList.remove("selected-month");
+      }
+    });
+
+    // Edge cases to disable the all or none selection buttons
+    // if the current state contains all or none of the months
+    if (Object.keys(eventTypeValue).length === 0) {
+      setDisableNoneSelection(true);
+    }
+    if (Object.keys(eventTypeForDate).length === 12) {
+      setDisableAllSelection(true);
+    }
+  }, [eventTypeValue, eventTypeForDate]);
+
   useEffect(() => {
     console.log("in disable effect");
     const allMonthsButton = document.querySelector(
@@ -113,12 +139,12 @@ export default function DateSelect(props: DateSelectProps) {
 
   function handleAllMonthSelect() {
     console.log("all month click");
-    const monthButtonList = document.querySelectorAll(
-      `.${eventTypeForDate}-month`
-    );
-    monthButtonList.forEach((monthButton) => {
-      monthButton.classList.add("selected-month");
-    });
+    // const monthButtonList = document.querySelectorAll(
+    //   `.${eventTypeForDate}-month`
+    // );
+    // monthButtonList.forEach((monthButton) => {
+    //   monthButton.classList.add("selected-month");
+    // });
     // Use the months object directly to set the state because
     // all months have been selected.
     onDateSelectChange(months);
@@ -129,12 +155,12 @@ export default function DateSelect(props: DateSelectProps) {
 
   function handleNoMonthSelect() {
     console.log("no month click");
-    const monthButtonList = document.querySelectorAll(
-      `.${eventTypeForDate}-month`
-    );
-    monthButtonList.forEach((monthButton) => {
-      monthButton.classList.remove("selected-month");
-    });
+    // const monthButtonList = document.querySelectorAll(
+    //   `.${eventTypeForDate}-month`
+    // );
+    // monthButtonList.forEach((monthButton) => {
+    //   monthButton.classList.remove("selected-month");
+    // });
     // Use empty object to set the state because none of the months
     // are selected
     onDateSelectChange({});

--- a/src/GardenPlanner.tsx
+++ b/src/GardenPlanner.tsx
@@ -92,12 +92,9 @@ export default function GardenPlanner() {
     // If an empty object was returned (when all months have been toggled off),
     // then need to explicitly re-set to arrays with empty strings, otherwise other code fails
     if (Object.keys(selectedMonthObj).length === 0) {
-      setBloomTime({ monthNumAsStringArray: [""], monthNameArray: [""] });
+      setBloomTime({});
     } else {
-      setBloomTime({
-        monthNumAsStringArray: Object.keys(selectedMonthObj),
-        monthNameArray: Object.values(selectedMonthObj),
-      });
+      setBloomTime({ ...selectedMonthObj });
     }
     console.log("bloom time object is:");
     console.log(bloomTime);
@@ -108,12 +105,9 @@ export default function GardenPlanner() {
     // If an empty object was returned (when all months have been toggled off),
     // then need to explicitly re-set to arrays with empty strings, otherwise other code fails
     if (Object.keys(selectedMonthObj).length === 0) {
-      setFruitTime({ monthNumAsStringArray: [""], monthNameArray: [""] });
+      setFruitTime({});
     } else {
-      setFruitTime({
-        monthNumAsStringArray: Object.keys(selectedMonthObj),
-        monthNameArray: Object.values(selectedMonthObj),
-      });
+      setFruitTime({ ...selectedMonthObj });
     }
     console.log("fruit time object is:");
     console.log(fruitTime);
@@ -124,12 +118,9 @@ export default function GardenPlanner() {
     // If an empty object was returned (when all months have been toggled off),
     // then need to explicitly re-set to arrays with empty strings, otherwise other code fails
     if (Object.keys(selectedMonthObj).length === 0) {
-      setOtherTime({ monthNumAsStringArray: [""], monthNameArray: [""] });
+      setOtherTime({});
     } else {
-      setOtherTime({
-        monthNumAsStringArray: Object.keys(selectedMonthObj),
-        monthNameArray: Object.values(selectedMonthObj),
-      });
+      setOtherTime({ ...selectedMonthObj });
     }
     console.log("other time object is:");
     console.log(otherTime);

--- a/src/GardenPlanner.tsx
+++ b/src/GardenPlanner.tsx
@@ -94,6 +94,7 @@ export default function GardenPlanner() {
     if (Object.keys(selectedMonthObj).length === 0) {
       setBloomTime({});
     } else {
+      // spread into new object so selectedMonthObj isn't wrapped in another object
       setBloomTime({ ...selectedMonthObj });
     }
     console.log("bloom time object is:");
@@ -107,11 +108,12 @@ export default function GardenPlanner() {
     if (Object.keys(selectedMonthObj).length === 0) {
       setFruitTime({});
     } else {
+      // spread into new object so selectedMonthObj isn't wrapped in another object
       setFruitTime({ ...selectedMonthObj });
     }
     console.log("fruit time object is:");
     console.log(fruitTime);
-    console.log(otherTime);
+    //console.log(otherTime);
   }
 
   function handleOtherTimeChange(selectedMonthObj: { [key: number]: string }) {
@@ -120,11 +122,12 @@ export default function GardenPlanner() {
     if (Object.keys(selectedMonthObj).length === 0) {
       setOtherTime({});
     } else {
+      // spread into new object so selectedMonthObj isn't wrapped in another object
       setOtherTime({ ...selectedMonthObj });
     }
     console.log("other time object is:");
     console.log(otherTime);
-    console.log(fruitTime);
+    //console.log(fruitTime);
   }
 
   //console.log(`The bloom time is: ${bloomTime["monthNameArray"]}`);
@@ -542,6 +545,7 @@ export default function GardenPlanner() {
       <AddPlant
         plantName={plantName}
         onNameChange={handleNameChange}
+        bloomColorName={bloomColorName}
         bloomTime={bloomTime}
         fruitTime={fruitTime}
         otherTime={otherTime}

--- a/src/GardenPlanner.tsx
+++ b/src/GardenPlanner.tsx
@@ -19,18 +19,9 @@ import { BloomFruitTimeObj, PlantsType } from "./GardenPlannerInterfaces";
 
 export default function GardenPlanner() {
   const [plantName, setPlantName] = useState("");
-  const [bloomTime, setBloomTime] = useState({
-    monthNumAsStringArray: [""],
-    monthNameArray: [""],
-  });
-  const [fruitTime, setFruitTime] = useState({
-    monthNumAsStringArray: [""],
-    monthNameArray: [""],
-  });
-  const [otherTime, setOtherTime] = useState({
-    monthNumAsStringArray: [""],
-    monthNameArray: [""],
-  });
+  const [bloomTime, setBloomTime] = useState({});
+  const [fruitTime, setFruitTime] = useState({});
+  const [otherTime, setOtherTime] = useState({});
   const [bloomColor, setBloomColor] = useState("");
   const [bloomColorName, setBloomColorName] = useState("");
   // This sets the useState object type to be more inclusive and take any string as a key
@@ -249,6 +240,34 @@ export default function GardenPlanner() {
         wildlifeAttractedOther: wildlifeAttractedOther,
       },
     ]);
+    // Reset the values of the controlled elements after a plant is
+    // added in order to clear the AddPlant form
+    setPlantName("");
+    setBloomTime({});
+    setFruitTime({});
+    setOtherTime({});
+    setBloomColor("");
+    setBloomColorName("");
+    setWildlifeAttractedBloom({
+      bees: false,
+      butterflies: false,
+      hummingbirds: false,
+      songbirds: false,
+      other: false,
+    });
+    setWildlifeAttractedFruit({
+      songbirds: false,
+      mammals: false,
+      other: false,
+    });
+    setWildlifeAttractedOther({
+      bees: false,
+      butterflies: false,
+      hummingbirds: false,
+      songbirds: false,
+      mammals: false,
+      other: false,
+    });
   }
   //console.log(`Here's the plant list:`);
   //console.log(plants);
@@ -433,23 +452,23 @@ export default function GardenPlanner() {
       console.log("plant entry");
       console.log(plant);
       // Need to add 'Time' to the end of each of the event types for the lookup to match a key
-      let inputPlantEventArray = plant[
+      let inputPlantEventObject = plant[
         `${eventTypeToSort}Time` as keyof PlantsType
-      ] as BloomFruitTimeObj;
+      ] as keyof BloomFruitTimeObj;
       // Get the first month of the event. Will be used to index into the correct month key in the holderObj
       // If the startEventMonth would otherwise be undefined (if there's no plant event e.g. bloom specified for the current plant)
       // then set the start month to "Jan"
       const startEventMonth =
-        inputPlantEventArray.monthNameArray[0] === undefined ||
-        inputPlantEventArray.monthNameArray[0] !== ""
-          ? inputPlantEventArray.monthNameArray[0]
+        Object.values(inputPlantEventObject)[0] === undefined ||
+        Object.values(inputPlantEventObject)[0] !== ""
+          ? Object.values(inputPlantEventObject)[0]
           : "Jan";
       // returns 0 duration if the current plant doesn't have the event (e.g. blooming) specified
       let firstEventDuration = getFirstEventDuration(
-        inputPlantEventArray.monthNumAsStringArray
+        Object.keys(inputPlantEventObject)
       );
 
-      console.log(inputPlantEventArray.monthNameArray[0]);
+      console.log(Object.values(inputPlantEventObject)[0]);
       console.log({ startEventMonth });
       console.log({ firstEventDuration });
 

--- a/src/GardenPlannerInterfaces.d.ts
+++ b/src/GardenPlannerInterfaces.d.ts
@@ -49,6 +49,7 @@ interface WildlifeAttractedOtherType {
 export interface PlantsType {
   id: number;
   plantName: string;
+  bloomColorName: string;
   bloomTime: BloomFruitTimeObj;
   fruitTime: BloomFruitTimeObj;
   otherTime: BloomFruitTimeObj;

--- a/src/GardenPlannerInterfaces.d.ts
+++ b/src/GardenPlannerInterfaces.d.ts
@@ -1,8 +1,3 @@
-export interface BloomTime {
-  monthNumAsStringArray: string[];
-  monthNameArray: string[];
-}
-
 // interfaces are only used for object types. `type` can be used to alias the type
 // for other features e.g. functions.
 //type BloomColorChange = (hexColor: string, colorName: string) => void;
@@ -14,8 +9,7 @@ export interface DateSelectionObj {
 }
 
 export interface BloomFruitTimeObj {
-  monthNumAsStringArray: string[];
-  monthNameArray: string[];
+  [key: number]: string;
 }
 
 // Not currently used and has some problems in trying to generalize the wildlife updates

--- a/src/Plant.tsx
+++ b/src/Plant.tsx
@@ -114,17 +114,18 @@ export default function Plant(props: PlantProps) {
     "D",
   ];
 
-  // Convert from string array to numeric to allow matching by index with monthsFirstLetter array to render
+  // Convert from string array of month numbers (keys) to numeric to allow matching by index with monthsFirstLetter array to render
   // month diagram in plant card.
-  let bloomMonthsNumeric = props.plantInfo.bloomTime.monthNumAsStringArray.map(
+  let bloomMonthsNumeric = Object.keys(props.plantInfo.bloomTime).map(
+    (monthString) => Number.parseInt(monthString, 10)
+  );
+  console.log("bloom months numeric is:");
+  console.log(bloomMonthsNumeric);
+  let fruitMonthsNumeric = Object.keys(props.plantInfo.fruitTime).map(
     (monthString) => Number.parseInt(monthString, 10)
   );
 
-  let fruitMonthsNumeric = props.plantInfo.fruitTime.monthNumAsStringArray.map(
-    (monthString) => Number.parseInt(monthString, 10)
-  );
-
-  let otherMonthsNumeric = props.plantInfo.otherTime.monthNumAsStringArray.map(
+  let otherMonthsNumeric = Object.keys(props.plantInfo.otherTime).map(
     (monthString) => Number.parseInt(monthString, 10)
   );
   return (

--- a/src/PlantPlot.tsx
+++ b/src/PlantPlot.tsx
@@ -185,6 +185,8 @@ export default function PlantPlot(props: PlantPlotProps) {
         ] as BloomFruitTimeObj;
         // The month numbers are the keys
         Object.keys(inputPlantEventArray).forEach((timeEntryStr) => {
+          console.log("looping through inputPlantEventArray");
+          console.log(timeEntryStr);
           const timeEntryNum = Number.parseInt(timeEntryStr, 10);
           // Fill in the graph entry to span the bloom month start and the bloom month end
           // Graph indices are 0-based

--- a/src/PlantPlot.tsx
+++ b/src/PlantPlot.tsx
@@ -78,15 +78,17 @@ export default function PlantPlot(props: PlantPlotProps) {
 
   function determinePlantCharsToPlot(inputPlantObj: PlantsType) {
     let plantCharacteristicsToPlot: string[] = [];
-    if (inputPlantObj.bloomTime.monthNameArray.length > 0) {
+    if (Object.keys(inputPlantObj.bloomTime).length > 0) {
       plantCharacteristicsToPlot.push("bloomTime");
     }
-    if (inputPlantObj.fruitTime.monthNameArray.length > 0) {
+    if (Object.keys(inputPlantObj.fruitTime).length > 0) {
       plantCharacteristicsToPlot.push("fruitTime");
     }
-    if (inputPlantObj.otherTime.monthNameArray.length > 0) {
+    if (Object.keys(inputPlantObj.otherTime).length > 0) {
       plantCharacteristicsToPlot.push("otherTime");
     }
+    // console.log("Plant chars to plot are");
+    // console.log(plantCharacteristicsToPlot);
     return plantCharacteristicsToPlot;
   }
 
@@ -181,8 +183,8 @@ export default function PlantPlot(props: PlantPlotProps) {
         let inputPlantEventArray = inputPlantObj[
           plantEvent as keyof PlantsType
         ] as BloomFruitTimeObj;
-
-        inputPlantEventArray.monthNumAsStringArray.forEach((timeEntryStr) => {
+        // The month numbers are the keys
+        Object.keys(inputPlantEventArray).forEach((timeEntryStr) => {
           const timeEntryNum = Number.parseInt(timeEntryStr, 10);
           // Fill in the graph entry to span the bloom month start and the bloom month end
           // Graph indices are 0-based
@@ -293,7 +295,8 @@ export default function PlantPlot(props: PlantPlotProps) {
       //console.log("currentPlantChar");
       //console.log({ currentPlantChar });
       let labelXAxisLocArray = parseWildlifeArrayForLabels(
-        currPlantCharObj.monthNameArray
+        // These are the month names
+        Object.values(currPlantCharObj)
       );
       //console.log("x axis loc array");
       //console.log(labelXAxisLocArray);
@@ -405,7 +408,10 @@ export default function PlantPlot(props: PlantPlotProps) {
       // Return 1 label object (with unique id key in the holderObj)
       // for each of the bloom, fruit, and other label x locations, which
       // are placed at the left end of each disjunct line segment in their graphs.
-      if (plotWildlifeLocations_bloom.length > 0) {
+      if (
+        plotWildlifeLocations_bloom !== undefined &&
+        plotWildlifeLocations_bloom.length > 0
+      ) {
         for (
           let bloomIndex = 0;
           bloomIndex < plotWildlifeLocations_bloom.length;
@@ -432,7 +438,10 @@ export default function PlantPlot(props: PlantPlotProps) {
       //   content: currWildlife.bloom.join(", "),
       //   position: { x: "start", y: "center" },
       // };
-      if (plotWildlifeLocations_fruit.length > 0) {
+      if (
+        plotWildlifeLocations_fruit !== undefined &&
+        plotWildlifeLocations_fruit.length > 0
+      ) {
         for (
           let fruitIndex = 0;
           fruitIndex < plotWildlifeLocations_fruit.length;
@@ -455,7 +464,10 @@ export default function PlantPlot(props: PlantPlotProps) {
         }
       }
 
-      if (plotWildlifeLocations_other.length > 0) {
+      if (
+        plotWildlifeLocations_other !== undefined &&
+        plotWildlifeLocations_other.length > 0
+      ) {
         for (
           let otherIndex = 0;
           otherIndex < plotWildlifeLocations_other.length;


### PR DESCRIPTION
Lifted the state management for the color and the date selectors to the central GardenPlanner component and updated code to allow GardenPlanner to re-set the plant form once the 'Add' button is clicked. Verified this also means GardenPlanner can also set the color and dates to any arbitrary values through the state. This is a precursor to being able to edit entries (after loading them into the form) for existing plants.